### PR TITLE
Adding green and yellow theme colors, formatting edits for readability & consistency 

### DIFF
--- a/src/main/java/io/jenkins/plugins/materialtheme/MaterialGreenThemeManagerFactory.java
+++ b/src/main/java/io/jenkins/plugins/materialtheme/MaterialGreenThemeManagerFactory.java
@@ -1,0 +1,48 @@
+package io.jenkins.plugins.materialtheme;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import io.jenkins.plugins.thememanager.ThemeManagerFactory;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class MaterialGreenThemeManagerFactory extends AbstractMaterialTheme {
+
+    public static final String MATERIAL_GREEN_CSS = "theme-green.css";
+    public static final String MATERIAL_GREEN_SYMBOL = "material-green";
+
+    @DataBoundConstructor
+    public MaterialGreenThemeManagerFactory() {
+    }
+
+    @Extension
+    @Symbol(MATERIAL_GREEN_SYMBOL)
+    public static class MaterialGreenThemeManagerFactoryDescriptor extends AbstractMaterialThemeDescriptor {
+
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return "Material - Green";
+        }
+
+        @Override
+        public ThemeManagerFactory getInstance() {
+            return new MaterialGreenThemeManagerFactory();
+        }
+
+        @Override
+        public String getThemeCssSuffix() {
+            return MATERIAL_GREEN_CSS;
+        }
+
+        @Override
+        public String getThemeKey() {
+            return ID + "-green";
+        }
+
+        @Override
+        public boolean isNamespaced() {
+            return true;
+        }
+    }
+}

--- a/src/main/java/io/jenkins/plugins/materialtheme/MaterialGreyThemeManagerFactory.java
+++ b/src/main/java/io/jenkins/plugins/materialtheme/MaterialGreyThemeManagerFactory.java
@@ -2,9 +2,7 @@ package io.jenkins.plugins.materialtheme;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import io.jenkins.plugins.thememanager.Theme;
 import io.jenkins.plugins.thememanager.ThemeManagerFactory;
-import io.jenkins.plugins.thememanager.ThemeManagerFactoryDescriptor;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 

--- a/src/main/java/io/jenkins/plugins/materialtheme/MaterialLightBlueThemeManagerFactory.java
+++ b/src/main/java/io/jenkins/plugins/materialtheme/MaterialLightBlueThemeManagerFactory.java
@@ -2,9 +2,7 @@ package io.jenkins.plugins.materialtheme;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
-import io.jenkins.plugins.thememanager.Theme;
 import io.jenkins.plugins.thememanager.ThemeManagerFactory;
-import io.jenkins.plugins.thememanager.ThemeManagerFactoryDescriptor;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 

--- a/src/main/java/io/jenkins/plugins/materialtheme/MaterialThemeRootAction.java
+++ b/src/main/java/io/jenkins/plugins/materialtheme/MaterialThemeRootAction.java
@@ -17,6 +17,8 @@ import static io.jenkins.plugins.materialtheme.MaterialIndigoThemeManagerFactory
 import static io.jenkins.plugins.materialtheme.MaterialRedThemeManagerFactory.MATERIAL_RED_CSS;
 import static io.jenkins.plugins.materialtheme.MaterialGreyThemeManagerFactory.MATERIAL_GREY_CSS;
 import static io.jenkins.plugins.materialtheme.MaterialLightBlueThemeManagerFactory.MATERIAL_LIGHT_BLUE_CSS;
+import static io.jenkins.plugins.materialtheme.MaterialGreenThemeManagerFactory.MATERIAL_GREEN_CSS;
+import static io.jenkins.plugins.materialtheme.MaterialYellowThemeManagerFactory.MATERIAL_YELLOW_CSS;
 
 @Extension
 public class MaterialThemeRootAction implements UnprotectedRootAction {
@@ -41,7 +43,7 @@ public class MaterialThemeRootAction implements UnprotectedRootAction {
         if (cssFile.startsWith("/")) {
             cssFile = cssFile.substring(1);
         }
-        if (!Arrays.asList(BASE_CSS, MATERIAL_INDIGO_CSS, MATERIAL_RED_CSS, MATERIAL_GREY_CSS, MATERIAL_LIGHT_BLUE_CSS, CUSTOMISED_CSS)
+        if (!Arrays.asList(BASE_CSS, MATERIAL_INDIGO_CSS, MATERIAL_RED_CSS, MATERIAL_GREY_CSS, MATERIAL_LIGHT_BLUE_CSS, MATERIAL_GREEN_CSS, MATERIAL_YELLOW_CSS, CUSTOMISED_CSS)
                 .contains(cssFile)) {
             rsp.sendError(404);
             return;

--- a/src/main/java/io/jenkins/plugins/materialtheme/MaterialYellowThemeManagerFactory.java
+++ b/src/main/java/io/jenkins/plugins/materialtheme/MaterialYellowThemeManagerFactory.java
@@ -1,0 +1,48 @@
+package io.jenkins.plugins.materialtheme;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import io.jenkins.plugins.thememanager.ThemeManagerFactory;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class MaterialYellowThemeManagerFactory extends AbstractMaterialTheme {
+
+    public static final String MATERIAL_YELLOW_CSS = "theme-yellow.css";
+    public static final String MATERIAL_YELLOW_SYMBOL = "material-yellow";
+
+    @DataBoundConstructor
+    public MaterialYellowThemeManagerFactory() {
+    }
+
+    @Extension
+    @Symbol(MATERIAL_YELLOW_SYMBOL)
+    public static class MaterialYellowThemeManagerFactoryDescriptor extends AbstractMaterialThemeDescriptor {
+
+        @NonNull
+        @Override
+        public String getDisplayName() {
+            return "Material - Yellow";
+        }
+
+        @Override
+        public ThemeManagerFactory getInstance() {
+            return new MaterialYellowThemeManagerFactory();
+        }
+
+        @Override
+        public String getThemeCssSuffix() {
+            return MATERIAL_YELLOW_CSS;
+        }
+
+        @Override
+        public String getThemeKey() {
+            return ID + "-yellow";
+        }
+
+        @Override
+        public boolean isNamespaced() {
+            return true;
+        }
+    }
+}

--- a/src/main/webapp/material-theme.css
+++ b/src/main/webapp/material-theme.css
@@ -113,7 +113,10 @@
 [data-theme=material-red], .app-theme-picker__picker[data-theme=material-red],
 [data-theme=material-indigo], .app-theme-picker__picker[data-theme=material-indigo],
 [data-theme=material-grey], .app-theme-picker__picker[data-theme=material-grey] ,
-[data-theme=material-light-blue], .app-theme-picker__picker[data-theme=material-light-blue] {
+[data-theme=material-light-blue], .app-theme-picker__picker[data-theme=material-light-blue],
+[data-theme=material-green], .app-theme-picker__picker[data-theme=material-green],
+[data-theme=material-yellow], .app-theme-picker__picker[data-theme=material-yellow]
+{
     /* Font */
     --font-family-sans: Roboto !important;
 
@@ -162,7 +165,13 @@
 }
 
 /* Manually change some header settings (these aren't available through theme.less */
-[data-theme=material-red] #header, [data-theme=material-indigo] #header, [data-theme=material-grey] #header, [data-theme=material-light-blue] #header {
+[data-theme=material-red] #header,
+[data-theme=material-indigo] #header,
+[data-theme=material-grey] #header,
+[data-theme=material-light-blue] #header,
+[data-theme=material-green] #header,
+[data-theme=material-yellow] #header
+{
     height: 64px;
     text-transform: uppercase;
     padding: 12px 10px;
@@ -170,37 +179,65 @@
 
 /* Change tab background so tabs don't float when there are multiple rows
 this doesn't look great, but I think it's less bad than when it's left white. */
-[data-theme=material-red] .tabBarFrame, [data-theme=material-indigo] .tabBarFrame, [data-theme=material-grey] .tabBarFrame, [data-theme=material-light-blue] .tabBarFrame {
+[data-theme=material-red] .tabBarFrame,
+[data-theme=material-indigo] .tabBarFrame,
+[data-theme=material-grey] .tabBarFrame,
+[data-theme=material-light-blue] .tabBarFrame,
+[data-theme=material-green] .tabBarFrame,
+[data-theme=material-yellow] .tabBarFrame
+{
     position: relative;
     background: var(--very-light-grey);
 }
 
-[data-theme=material-red] .yui-button button, [data-theme=material-indigo] .yui-button button, [data-theme=material-grey] .yui-button button, [data-theme=material-light-blue] .yui-button button {
+[data-theme=material-red] .yui-button button,
+[data-theme=material-indigo] .yui-button button,
+[data-theme=material-grey] .yui-button button,
+[data-theme=material-light-blue] .yui-button button,
+[data-theme=material-green] .yui-button button,
+[data-theme=material-yellow] .yui-button button
+{
     text-transform: uppercase;
 }
 
-[data-theme=material-red] a, [data-theme=material-indigo] a, [data-theme=material-grey] a, [data-theme=material-light-blue] a,
-[data-theme=material-red] a:link, [data-theme=material-indigo] a:link, [data-theme=material-grey] a:link, [data-theme=material-light-blue] a:link,
-[data-theme=material-red] a:hover, [data-theme=material-indigo] a:hover, [data-theme=material-grey] a:hover, [data-theme=material-light-blue] a:hover,
-[data-theme=material-red] a:visited, [data-theme=material-indigo] a:visited, [data-theme=material-grey] a:visited, [data-theme=material-light-blue] a:visited
+[data-theme=material-red] a, [data-theme=material-red] a:link, [data-theme=material-red] a:hover, [data-theme=material-red] a:visited,
+[data-theme=material-indigo] a, [data-theme=material-indigo] a:link, [data-theme=material-indigo] a:hover, [data-theme=material-indigo] a:visited,
+[data-theme=material-grey] a, [data-theme=material-grey] a:link, [data-theme=material-grey] a:hover, [data-theme=material-grey] a:visited,
+[data-theme=material-light-blue] a, [data-theme=material-light-blue] a:link, [data-theme=material-light-blue] a:hover, [data-theme=material-light-blue] a:visited,
+[data-theme=material-green] a, [data-theme=material-green] a:link, [data-theme=material-green] a:hover, [data-theme=material-green] a:visited,
+[data-theme=material-yellow] a, [data-theme=material-yellow] a:link, [data-theme=material-yellow] a:hover, [data-theme=material-yellow] a:visited
 {
     text-decoration: none!important;
 }
 
-[data-theme=material-red] .jenkins_ver:after, [data-theme=material-indigo] .jenkins_ver:after, [data-theme=material-grey] .jenkins_ver:after, [data-theme=material-light-blue] .jenkins_ver:after {
+[data-theme=material-red] .jenkins_ver:after,
+[data-theme=material-indigo] .jenkins_ver:after,
+[data-theme=material-grey] .jenkins_ver:after,
+[data-theme=material-light-blue] .jenkins_ver:after,
+[data-theme=material-green] .jenkins_ver:after,
+[data-theme=material-yellow] .jenkins_ver:after
+{
     margin-left: 15px;
     content:"Material Theme Plugin"
 }
 
 /* Console readablity improvements */
-[data-theme=material-red] .console-output, [data-theme=material-indigo] .console-output, [data-theme=material-grey] .console-output, [data-theme=material-light-blue] .console-output {
+[data-theme=material-red] .console-output,
+[data-theme=material-indigo] .console-output,
+[data-theme=material-grey] .console-output,
+[data-theme=material-light-blue] .console-output,
+[data-theme=material-green] .console-output,
+[data-theme=material-yellow] .console-output
+{
     padding: 10px 20px;
 }
 
-[data-theme=material-red] .console-output, [data-theme=material-indigo] .console-output,
-[data-theme=material-red] .console-output *, [data-theme=material-indigo] .console-output *,
-[data-theme=material-grey] .console-output, [data-theme=material-light-blue] .console-output,
-[data-theme=material-grey] .console-output *, [data-theme=material-light-blue] .console-output *
+[data-theme=material-red] .console-output, [data-theme=material-red] .console-output *,
+[data-theme=material-indigo] .console-output, [data-theme=material-indigo] .console-output *,
+[data-theme=material-grey] .console-output, [data-theme=material-grey] .console-output *,
+[data-theme=material-light-blue] .console-output, [data-theme=material-light-blue] .console-output *,
+[data-theme=material-green] .console-output, [data-theme=material-green] .console-output *,
+[data-theme=material-yellow] .console-output, [data-theme=material-yellow] .console-output *
 {
   position: relative;
   font-family: Roboto Mono,monospace!important;
@@ -209,7 +246,12 @@ this doesn't look great, but I think it's less bad than when it's left white. */
   cursor: text;
 }
 
-[data-theme=material-red] pre.console-output, [data-theme=material-indigo] pre.console-output, [data-theme=material-grey] pre.console-output, [data-theme=material-light-blue] pre.console-output
+[data-theme=material-red] pre.console-output,
+[data-theme=material-indigo] pre.console-output,
+[data-theme=material-grey] pre.console-output,
+[data-theme=material-light-blue] pre.console-output,
+[data-theme=material-green] pre.console-output,
+[data-theme=material-yellow] pre.console-output
 {
   color: #e9eded!important;
 }

--- a/src/main/webapp/resources/less/core-theme.less
+++ b/src/main/webapp/resources/less/core-theme.less
@@ -1,5 +1,11 @@
 // Copyright (c) 2016 Afonso F
-[data-theme=material-red], [data-theme=material-indigo], [data-theme=material-grey], [data-theme=material-light-blue] {
+[data-theme=material-red],
+[data-theme=material-indigo],
+[data-theme=material-grey],
+[data-theme=material-light-blue],
+[data-theme=material-green],
+[data-theme=material-yellow]
+{
   // Copied from functions.less
   // Change to use masks - so we can change svg icon color
   .icon-img(@url, @icon-color) {

--- a/src/main/webapp/resources/less/light-theme.less
+++ b/src/main/webapp/resources/less/light-theme.less
@@ -4,7 +4,7 @@
 @color-text: #444;
 @color-link: #26a69a;
 @color-grey: #9E9E9E;
-@color-green: #009688;
+@color-green: #43A047;
 @color-yellow: #FFC107;
 @color-red: #F44336;
 @color-white: #fff;

--- a/src/main/webapp/theme-green.css
+++ b/src/main/webapp/theme-green.css
@@ -1,0 +1,4 @@
+[data-theme=material-green], .app-theme-picker__picker[data-theme=material-green] {
+    --material-primary: #43A047;
+    --material-secondary: #65AA69;
+}

--- a/src/main/webapp/theme-yellow.css
+++ b/src/main/webapp/theme-yellow.css
@@ -1,0 +1,4 @@
+[data-theme=material-yellow], .app-theme-picker__picker[data-theme=material-yellow] {
+    --material-primary: #FFC107;
+    --material-secondary: #F4C24F;
+}

--- a/src/test/java/io/jenkins/plugins/materialtheme/jcasc/materialgreen/MaterialGreenThemeJcascTest.java
+++ b/src/test/java/io/jenkins/plugins/materialtheme/jcasc/materialgreen/MaterialGreenThemeJcascTest.java
@@ -1,0 +1,50 @@
+package io.jenkins.plugins.materialtheme.jcasc.materialgreen;
+
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.thememanager.ThemeManagerFactory;
+import io.jenkins.plugins.thememanager.ThemeManagerPageDecorator;
+import org.junit.ClassRule;
+import org.junit.Test;
+import io.jenkins.plugins.materialtheme.MaterialGreenThemeManagerFactory;
+
+import static io.jenkins.plugins.casc.misc.Util.getUnclassifiedRoot;
+import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
+import static io.jenkins.plugins.casc.misc.Util.toYamlString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
+
+public class MaterialGreenThemeJcascTest {
+
+  @ClassRule
+  @ConfiguredWithCode("ConfigurationAsCode.yml")
+  public static JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+  @Test
+  public void testConfig() {
+    ThemeManagerPageDecorator decorator = ThemeManagerPageDecorator.get();
+
+    ThemeManagerFactory theme = decorator.getTheme();
+    assertNotNull(theme);
+
+    assertThat(decorator.isDisableUserThemes(), is(true));
+    assertThat(theme, instanceOf(MaterialGreenThemeManagerFactory.class));
+  }
+
+  @Test
+  public void testExport() throws Exception {
+    ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+    CNode yourAttribute = getUnclassifiedRoot(context).get("themeManager");
+
+    String exported = toYamlString(yourAttribute);
+
+    String expected = toStringFromYamlFile(this, "ConfigurationAsCodeExport.yml");
+
+    assertThat(exported, is(expected));
+  }
+}

--- a/src/test/java/io/jenkins/plugins/materialtheme/jcasc/materialyellow/MaterialYellowThemeJcascTest.java
+++ b/src/test/java/io/jenkins/plugins/materialtheme/jcasc/materialyellow/MaterialYellowThemeJcascTest.java
@@ -1,0 +1,50 @@
+package io.jenkins.plugins.materialtheme.jcasc.materialyellow;
+
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.thememanager.ThemeManagerFactory;
+import io.jenkins.plugins.thememanager.ThemeManagerPageDecorator;
+import org.junit.ClassRule;
+import org.junit.Test;
+import io.jenkins.plugins.materialtheme.MaterialYellowThemeManagerFactory;
+
+import static io.jenkins.plugins.casc.misc.Util.getUnclassifiedRoot;
+import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
+import static io.jenkins.plugins.casc.misc.Util.toYamlString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
+
+public class MaterialYellowThemeJcascTest {
+
+  @ClassRule
+  @ConfiguredWithCode("ConfigurationAsCode.yml")
+  public static JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+  @Test
+  public void testConfig() {
+    ThemeManagerPageDecorator decorator = ThemeManagerPageDecorator.get();
+
+    ThemeManagerFactory theme = decorator.getTheme();
+    assertNotNull(theme);
+
+    assertThat(decorator.isDisableUserThemes(), is(true));
+    assertThat(theme, instanceOf(MaterialYellowThemeManagerFactory.class));
+  }
+
+  @Test
+  public void testExport() throws Exception {
+    ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+    CNode yourAttribute = getUnclassifiedRoot(context).get("themeManager");
+
+    String exported = toYamlString(yourAttribute);
+
+    String expected = toStringFromYamlFile(this, "ConfigurationAsCodeExport.yml");
+
+    assertThat(exported, is(expected));
+  }
+}

--- a/src/test/resources/io/jenkins/plugins/materialtheme/jcasc/materialgreen/ConfigurationAsCode.yml
+++ b/src/test/resources/io/jenkins/plugins/materialtheme/jcasc/materialgreen/ConfigurationAsCode.yml
@@ -1,0 +1,5 @@
+---
+unclassified:
+  themeManager:
+    disableUserThemes: true
+    theme: "material-green"

--- a/src/test/resources/io/jenkins/plugins/materialtheme/jcasc/materialgreen/ConfigurationAsCodeExport.yml
+++ b/src/test/resources/io/jenkins/plugins/materialtheme/jcasc/materialgreen/ConfigurationAsCodeExport.yml
@@ -1,0 +1,2 @@
+disableUserThemes: true
+theme: "material-green"

--- a/src/test/resources/io/jenkins/plugins/materialtheme/jcasc/materialyellow/ConfigurationAsCode.yml
+++ b/src/test/resources/io/jenkins/plugins/materialtheme/jcasc/materialyellow/ConfigurationAsCode.yml
@@ -1,0 +1,5 @@
+---
+unclassified:
+  themeManager:
+    disableUserThemes: true
+    theme: "material-yellow"

--- a/src/test/resources/io/jenkins/plugins/materialtheme/jcasc/materialyellow/ConfigurationAsCodeExport.yml
+++ b/src/test/resources/io/jenkins/plugins/materialtheme/jcasc/materialyellow/ConfigurationAsCodeExport.yml
@@ -1,0 +1,2 @@
+disableUserThemes: true
+theme: "material-yellow"


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Added a green and yellow themes
Also cleaned up some unused imports and reformatted the css a bit for better readability

Issue: https://github.com/jenkinsci/material-theme-plugin/issues/53

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

Note
I think I got everything setup for these, happy to modify as needed.
The readability is subjective I understand but consistency is not so thats what I went for.
Consistency was picked based on the first occurrence where each color was on its own line, this read nice and was easier to maintain in my opinion so I used that format for everywhere else. (https://github.com/jenkinsci/material-theme-plugin/blob/master/src/main/webapp/material-theme.css#L113-L116)

We needed these colors for our instances of jenkins that we previously used afonsof/jenkins-material-theme for; which this is based off of! Colors were taken from there, secondary colors are 75% opacity of the primary color.
