### PR TITLE
Update Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,5 @@
 
 buildPlugin(useAci: true, configurations: [
         [ platform: "linux", jdk: "8", jenkins: null ],
-        [ platform: "linux", jdk: "11", jenkins: null, javaLevel: "8" ]
+        [ platform: "linux", jdk: "11", jenkins: null ]
 ])


### PR DESCRIPTION
The javaLevel option is deprecated and does no longer set the Java version. The option is ignored.
This PR removes the unused option.

I'll expedite the merge, once the infrastructure changes on ci.jenkins.io are live, to prevent a failure on the master branch and new PRs.